### PR TITLE
Handle multiline bash escape as preparation step

### DIFF
--- a/src/Normalize.hs
+++ b/src/Normalize.hs
@@ -6,16 +6,33 @@ import Data.List (intercalate)
 import Data.List.Split (splitOn)
 import Debug.Trace
 
+escapePlaceHolder = "\\\\"
+escapeSeq = "\\\n"
+
 replace old new = intercalate new . splitOn old
+count s x = length (splitOn x s) - 1
+
+trimLines :: String -> String
+trimLines s = unlines $ map strip $ lines s
+  where
+    strip = lstrip . rstrip
+    lstrip = dropWhile (`elem` " \t")
+    rstrip = reverse . lstrip . reverse
+
+replaceEscapeSigns :: String -> String
+replaceEscapeSigns = replace escapeSeq escapePlaceHolder
+
+removeEscapePlaceholder :: String -> String
+removeEscapePlaceholder = replace escapePlaceHolder " "
+
+compensateLinebreaks :: String -> String
+compensateLinebreaks s = concatMap compensate $ lines s
+  where
+    compensate line = line ++ "\n" ++ genLinebreaks line
+    genLinebreaks line = concat $ replicate (count line escapePlaceHolder) "\n"
 
 -- | Remove new line escapes and join escaped lines together on one line
 --   to simplify parsing later on. Escapes are replaced with line breaks
 --   to not alter the line numbers.
 normalizeEscapedLines :: String -> String
-normalizeEscapedLines s = unwords escapedSegments ++ lineBreakReplacements
-  where
-    escapedSegments = splitOn escapeSequence s
-    lineBreakReplacements = concat $ replicate escapeOccurrences "\n"
-    -- count gaps between elements
-    escapeOccurrences = length escapedSegments - 1
-    escapeSequence = "\\\n"
+normalizeEscapedLines s = removeEscapePlaceholder $ compensateLinebreaks $ replaceEscapeSigns $ trimLines s

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -69,6 +69,7 @@ astTests =
     , "env works with cmd" ~: assertAst envWorksCmdProg envWorksCmdAst
     , "multicomments first" ~: assertAst multiCommentsProg1 [Run ["apt-get", "update"]]
     , "multicomments after" ~: assertAst multiCommentsProg2 [Run ["apt-get", "update"], Comment " line 1", Comment " line 2"]
+    , "escape with space" ~: assertAst escapedWithSpaceProgram [Run ["yum", "install", "-y", "imagemagick", "mysql"]]
     ] where
         maintainerFromProg = "FROM busybox\nMAINTAINER hudu@mail.com"
         maintainerFromAst = [ From (UntaggedImage "busybox")
@@ -86,6 +87,10 @@ astTests =
                                      , "# line 1"
                                      , "# line 2"
                                      ]
+        escapedWithSpaceProgram = unlines [ "RUN yum install -y \\ "
+                                          , "imagemagick \\ "
+                                          , "mysql"
+                                          ]
 
 ruleTests =
     [ "untagged" ~: ruleCatches noUntagged "FROM debian"


### PR DESCRIPTION
Most escaping problems should be resolved without code for each rule.