### PR TITLE
optparse-applicative: restrict to <0.13.0.0

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -35,7 +35,7 @@ executable hadolint
   build-depends:       base >=4.8 && < 5
                      , hadolint
                      , parsec >=3.1
-                     , optparse-applicative
+                     , optparse-applicative <0.13.0.0
   default-language:    Haskell2010
 
 test-suite hadolint-unit-tests


### PR DESCRIPTION
optparse-applicative: restrict to <0.13.0.0

Until hadolint has support for optparse-applicative >=0.13.0,
restricting it to <0.13.0.0 prevents build failure with errors such as
app/Main.hs:31:32: error:
```
    • Variable not in scope: (<>) :: Mod f0 a0 -> Mod f1 a1 -> t0
    • Perhaps you meant one of these:
        ‘<$>’ (imported from Options.Applicative),
        ‘<*>’ (imported from Options.Applicative),
        ‘>>’ (imported from Prelude)
```