### PR TITLE
Add "use SHELL" rule for ln with /bin/sh

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -77,6 +77,7 @@ rules = [ absoluteWorkdir
         , hasMaintainer
         , multipleCmds
         , multipleEntrypoints
+        , useShell
         ]
 
 commentMetadata :: ShellCheck.Interface.Comment -> Metadata
@@ -292,3 +293,11 @@ copyInsteadAdd = instructionRule code severity message check
           message = "Use COPY instead of ADD for files and folders"
           check (Add src _) = isArchive src || isUrl src
           check _ = True
+
+useShell = instructionRule code severity message check
+    where code = "DL4005"
+          severity = WarningC
+          message = "Use SHELL to change the default shell"
+          check (Run args) = not $ any shellSymlink (bashCommands args)
+          check _ = True
+          shellSymlink (args) = usingProgram "ln" args && isInfixOf ["/bin/sh"] args

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -195,6 +195,11 @@ main = hspec $ do
     it "pip install lower bound" $ ruleCatchesNot pipVersionPinned "RUN pip install 'alabaster<0.7'"
     it "pip install excluded version" $ ruleCatchesNot pipVersionPinned "RUN pip install 'alabaster!=0.7'"
 
+  describe "use SHELL" $ do
+    it "RUN ln" $ ruleCatches useShell "RUN ln -sfv /bin/bash /bin/sh"
+    it "RUN ln with unrelated symlinks" $ ruleCatchesNot useShell "RUN ln -sf /bin/true /sbin/initctl"
+    it "RUN ln with multiple acceptable commands" $ ruleCatchesNot useShell "RUN ln -s foo bar && unrelated && something_with /bin/sh"
+
   describe "other rules" $ do
     it "use add" $ ruleCatches useAdd "COPY packaged-app.tar /usr/src/app"
     it "use not add" $ ruleCatchesNot useAdd "COPY package.json /usr/src/app"


### PR DESCRIPTION
Addresses #59.

* I'm not sure how the numbering is decided for the rules so I just went with `DL4005` because it was the first number available after the highest `DL` number.

* There might be a better way to detect this shell symlinking behavior but right now I just assert that the `RUN` command is using `ln` and one of the arguments is `/bin/sh`. Open to suggestions for how to do this better. I'm not sure if this behaves well with chained commands for example (like `ln -s foo bar && something_with /bin/sh`)

* This doesn't handle anything for windows users. Noting this given that the docker reference recommends the `SHELL` instruction for windows users who prefix everything with `powershell -command ...`