### PR TITLE
Parse HEALTHCHECK 

### DIFF
--- a/src/Hadolint/Lexer.hs
+++ b/src/Hadolint/Lexer.hs
@@ -7,7 +7,7 @@ import qualified Text.Parsec.Token as Token
 lexer :: Token.TokenParser ()
 lexer = Token.makeTokenParser style
   where
-    names = ["FROM","ADD","RUN","WORKDIR","EXPOSE","VOLUME","ENTRYPOINT","MAINTAINER","ENV","LABEL","USER","STOPSIGNAL","CMD", "ONBUILD", "ARG"]
+    names = ["FROM","ADD","RUN","WORKDIR","EXPOSE","VOLUME","ENTRYPOINT","MAINTAINER","ENV","LABEL","USER","STOPSIGNAL","CMD", "ONBUILD", "ARG", "SHELL", "HEALTHCHECK"]
     style = emptyDef {
                Token.commentLine = "#"
              , Token.reservedNames = names

--- a/src/Hadolint/Parser.hs
+++ b/src/Hadolint/Parser.hs
@@ -189,7 +189,7 @@ argumentsExec = brackets $ commaSep stringLiteral
 argumentsShell :: Parser Arguments
 argumentsShell = do
     args <- untilEol
-    return $ words args 
+    return $ words args
 
 arguments :: Parser Arguments
 arguments = try argumentsExec <|> try argumentsShell
@@ -205,6 +205,12 @@ onbuild = do
   reserved "ONBUILD"
   i <- parseInstruction
   return $ OnBuild i
+
+healthcheck :: Parser Instruction
+healthcheck = do
+  reserved "HEALTHCHECK"
+  args <- untilEol
+  return $ Healthcheck args
 
 parseInstruction :: Parser Instruction
 parseInstruction
@@ -226,6 +232,7 @@ parseInstruction
     <|> try maintainer
     <|> try add
     <|> try comment
+    <|> try healthcheck
 
 contents :: Parser a -> Parser a
 contents p = do

--- a/src/Hadolint/Syntax.hs
+++ b/src/Hadolint/Syntax.hs
@@ -36,6 +36,7 @@ data Instruction
   | Maintainer String
   | Env Pairs
   | Arg String
+  | Healthcheck String
   | Comment String
   | OnBuild Instruction
   deriving (Eq, Ord, Show)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,6 +11,10 @@ import Data.Maybe (isJust, fromMaybe)
 
 main :: IO ()
 main = hspec $ do
+  describe "parse HEALTHCHECK" $
+    it "parse healthcheck without args" $
+        assertAst "HEALTHCHECK --interval=5m \\nCMD curl -f http://localhost/" [Healthcheck "--interval=5m \\nCMD curl -f http://localhost/"]
+
   describe "parse FROM" $
     it "parse untagged image" $
         assertAst "FROM busybox" [From (UntaggedImage "busybox")]


### PR DESCRIPTION
Just plain parse HEALTHCHECK (not even correctly) so people won't experience parser failures.
Resolves #62.