### PR TITLE
Unified error formatting 

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -57,7 +57,7 @@ lint (LintOptions _ ignored dfiles) = mapM_ (lintDockerfile ignored) dfiles
 
 checkAst :: (Check -> Bool) -> Either ParseError Dockerfile -> IO ()
 checkAst checkFilter ast = case ast of
-    Left err         -> print err >> exitSuccess
+    Left err         -> putStrLn (formatError err) >> exitSuccess
     Right dockerfile -> printChecks $ filter checkFilter $ analyzeAll dockerfile
 
 analyzeAll = analyze rules

--- a/src/Hadolint/Formatter.hs
+++ b/src/Hadolint/Formatter.hs
@@ -1,8 +1,20 @@
-module Hadolint.Formatter (formatCheck) where
+module Hadolint.Formatter (formatCheck, formatError) where
 
+import Data.Char (isSpace)
 import Control.Monad
 import Hadolint.Rules
 import Hadolint.Syntax
+import Text.Parsec.Error (Message, ParseError, messageString, errorPos, errorMessages, showErrorMessages)
+import Text.Parsec.Pos
+
+formatError :: ParseError -> String
+formatError err =  posPart ++ stripNewlines msgPart
+  where
+    pos = errorPos err
+    posPart = sourceName pos ++ ":" ++ show (sourceLine pos) ++ ":" ++ show (sourceColumn pos)
+    msgPart = showErrorMessages "or" "unknown parse error" "expecting" "unexpected" "end of input" (errorMessages err)
+    stripNewlines = map (\c -> if c =='\n' then ' ' else c)
+
 
 formatCheck :: Check -> String
 formatCheck (Check metadata source linenumber _) = formatPos source linenumber ++ code metadata ++ " " ++ message metadata

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,6 +1,7 @@
 import Test.Hspec
 import Test.HUnit hiding (Label)
 
+import Hadolint.Formatter
 import Hadolint.Parser
 import Hadolint.Rules
 import Hadolint.Syntax
@@ -80,7 +81,7 @@ main = hspec $ do
     it "quoted command params" $
         assertAst "CMD [\"echo\",  \"1\"]" [Cmd ["echo", "1"]]
 
-  describe "parse SHELL" $ do
+  describe "parse SHELL" $
     it "quoted shell params" $
         assertAst "SHELL [\"/bin/bash\",  \"-c\"]" [Shell ["/bin/bash", "-c"]]
 
@@ -242,6 +243,14 @@ main = hspec $ do
     it "add for xz" $ ruleCatchesNot copyInsteadAdd "ADD file.xz /usr/src/app/"
     it "add for tgz" $ ruleCatchesNot copyInsteadAdd "ADD file.tgz /usr/src/app/"
     it "add for url" $ ruleCatchesNot copyInsteadAdd "ADD http://file.com /usr/src/app/"
+
+  describe "format error" $
+    it "display error after line pos" $ do
+        let ast = parseString "FOM debian:jessie"
+            expectedMsg = "<string>:1:1 unexpected 'F' expecting space, \"\\t\", \"ONBUILD\", \"FROM\", \"COPY\", \"RUN\", \"WORKDIR\", \"ENTRYPOINT\", \"VOLUME\", \"EXPOSE\", \"ENV\", \"ARG\", \"USER\", \"LABEL\", \"STOPSIGNAL\", \"CMD\", \"SHELL\", \"MAINTAINER\", \"ADD\", \"#\", \"HEALTHCHECK\" or end of input"
+        case ast of
+            Left err -> assertEqual "Unexpected error msg" expectedMsg (formatError err)
+            Right _  -> assertFailure "AST should fail parsing"
 
 assertAst s ast = case parseString (s ++ "\n") of
     Left err          -> assertFailure $ show err


### PR DESCRIPTION
Resolves #57.

Now looks like this when parse error happens:

```
Dockerfile:3:1 unexpected 'B' expecting space, "\t", "ONBUILD", "FROM", "COPY", "RUN", "WORKDIR", "ENTRYPOINT", "VOLUME", "EXPOSE", "ENV", "ARG", "USER", "LABEL", "STOPSIGNAL", "CMD", "SHELL", "MAINTAINER", "ADD", "#" or end of input
```

Instead of

```
"/tmp/Dockerfile634358372" (line 1, column 5):
unexpected 'S'
expecting end of "CMD"
```