### PR TITLE
Upgrde for stackage lts 8.14

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,6 +11,7 @@ import Data.List (sort)
 import Text.Parsec (ParseError)
 import Control.Applicative
 import Options.Applicative hiding (ParseError)
+import Data.Semigroup
 
 type IgnoreRule = String
 data LintOptions = LintOptions { showVersion :: Bool

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -26,7 +26,7 @@ library
                      , parsec >=3.1
                      , bytestring >=0.10
                      , split >= 0.2
-                     , ShellCheck
+                     , ShellCheck >= 0.4.5
   default-language:    Haskell2010
 
 executable hadolint
@@ -46,7 +46,7 @@ test-suite hadolint-unit-tests
                      , parsec >=3.1
                      , bytestring >=0.10
                      , split >= 0.2
-                     , ShellCheck
+                     , ShellCheck >= 0.4.5
                      , HUnit >= 1.2
                      , hspec
                      , hadolint

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -35,7 +35,7 @@ executable hadolint
   build-depends:       base >=4.8 && < 5
                      , hadolint
                      , parsec >=3.1
-                     , optparse-applicative <0.13.0.0
+                     , optparse-applicative <0.13.3.0
   default-language:    Haskell2010
 
 test-suite hadolint-unit-tests

--- a/src/Hadolint/Bash.hs
+++ b/src/Hadolint/Bash.hs
@@ -6,7 +6,7 @@ import Data.Functor.Identity (runIdentity)
 
 shellcheck :: String -> [Comment]
 shellcheck bashScript = map comment $ crComments $ runIdentity $ checkScript si spec
-    where comment (PositionedComment _ c) = c
+    where comment (PositionedComment _ _ c) = c
           si = mockedSystemInterface [("","")]
           spec = CheckSpec filename script exclusions (Just Bash)
           script = "#!/bin/bash\n" ++ bashScript

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,14 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.9
+resolver: lts-8.14
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: [ShellCheck-0.4.4]
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This fixes issues with `optparse-applicative` and `ShellCheck`.

Fixes #72 