### PR TITLE
Reduced docker image size from 1,750MB to 2.48MB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -26,7 +26,7 @@ library
                      , parsec >=3.1
                      , bytestring >=0.10
                      , split >= 0.2
-                     , ShellCheck
+                     , ShellCheck < 0.4.5
   default-language:    Haskell2010
 
 executable hadolint

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,13 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.9
+resolver: lts-7.24
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
+build: { split-objs: true }
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps: [ShellCheck-0.4.4]
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-7.24
+resolver: lts-5.9
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
* Used Docker multistage builds to place static binary in busybox
* Updated to latest supported haskell Docker image
* Removed obsolete build step
* Added build requirements
* Manipulated crtbegin for static builds
* Used upx to further reduce from 8.35MB to 2.48MB
* Placed static executable in /bin to reduce final stage steps to two