### PR TITLE
Misc updates

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -26,7 +26,7 @@ library
                      , parsec >=3.1
                      , bytestring >=0.10
                      , split >= 0.2
-                     , ShellCheck
+                     , ShellCheck >= 0.4.6
   default-language:    Haskell2010
 
 executable hadolint
@@ -46,7 +46,7 @@ test-suite hadolint-unit-tests
                      , parsec >=3.1
                      , bytestring >=0.10
                      , split >= 0.2
-                     , ShellCheck
+                     , ShellCheck >= 0.4.6
                      , HUnit >= 1.2
                      , hspec
                      , hadolint

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -35,7 +35,7 @@ executable hadolint
   build-depends:       base >=4.8 && < 5
                      , hadolint
                      , parsec >=3.1
-                     , optparse-applicative <0.13.0.0
+                     , optparse-applicative >=0.12.0.0 && <0.13.0.0
   default-language:    Haskell2010
 
 test-suite hadolint-unit-tests

--- a/src/Hadolint/Bash.hs
+++ b/src/Hadolint/Bash.hs
@@ -6,7 +6,7 @@ import Data.Functor.Identity (runIdentity)
 
 shellcheck :: String -> [Comment]
 shellcheck bashScript = map comment $ crComments $ runIdentity $ checkScript si spec
-    where comment (PositionedComment _ c) = c
+    where comment (PositionedComment _ _ c) = c
           si = mockedSystemInterface [("","")]
           spec = CheckSpec filename script exclusions (Just Bash)
           script = "#!/bin/bash\n" ++ bashScript


### PR DESCRIPTION
Newer version of ShellCheck needed updates, and for some reason during build I got version 0.0.1 of optparse-applicative , so set a minimum that works.  These were during a cabal build of hadolint.