### PR TITLE
Call exitFailure if Dockerfile cannot be parsed or one is not provided

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -52,7 +52,7 @@ lintDockerfile ignoreRules dockerfile = do
 
 lint :: LintOptions -> IO ()
 lint (LintOptions True _ _) = putStrLn "Haskell Dockerfile Linter v1.2.1" >> exitSuccess
-lint (LintOptions _ _ []) = putStrLn "Please provide a Dockerfile" >> exitSuccess
+lint (LintOptions _ _ []) = putStrLn "Please provide a Dockerfile" >> exitFailure
 lint (LintOptions _ ignored dfiles) = mapM_ (lintDockerfile ignored) dfiles
 
 checkAst :: (Check -> Bool) -> Either ParseError Dockerfile -> IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -57,7 +57,7 @@ lint (LintOptions _ ignored dfiles) = mapM_ (lintDockerfile ignored) dfiles
 
 checkAst :: (Check -> Bool) -> Either ParseError Dockerfile -> IO ()
 checkAst checkFilter ast = case ast of
-    Left err         -> putStrLn (formatError err) >> exitSuccess
+    Left err         -> putStrLn (formatError err) >> exitFailure
     Right dockerfile -> printChecks $ filter checkFilter $ analyzeAll dockerfile
 
 analyzeAll = analyze rules


### PR DESCRIPTION
Calling `exitFailure` is useful when invoking `hadolint` in a script before building an image with a malformed Dockerfile; we can prevent a potentially time-consuming but ultimately doomed build this way.

Furthermore, calling `exitFailure` if no Dockerfile has been given provides better feedback to the user (or calling script) that `hadolint` has been misused.


References #95 