### PR TITLE
Update dependencies + multistage docker image + version from git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.hi
 *.o
 .stack-work
+tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,27 @@ matrix:
     compiler: ": #stack nightly osx"
     os: osx
 
+  - env: Build_Docker_Image
+    sudo: required
+    services:
+      - docker
+    addons:
+      apt:
+        packages:
+          - docker-ce
+    before_install: true
+    install:
+      # Build image
+      - docker build -t hadolint:$(git describe --tags --dirty) .
+    script:
+      # List images
+      - docker image ls
+      # Lint its own Dockerfile
+      - docker run --rm -i hadolint:$(git describe --tags --dirty) < Dockerfile
+      # Check that version in hadolint in the same as its `git describe`
+      # This can be enabled when there is an annotated tag
+      # - grep $(git describe --dirty) <<< $(docker run --rm -i hadolint:$(git describe --tags --dirty) hadolint --version)
+
   allow_failures:
   - env: BUILD=stack ARGS="--resolver nightly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,26 +27,26 @@ matrix:
   # variable, such as using --stack-yaml to point to a different file.
   - env: BUILD=stack ARGS=""
     compiler: ": #stack default"
-    addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+    addons: {apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-5"
-    compiler: ": #stack 7.10.3"
+  - env: BUILD=stack ARGS="--resolver lts-9.10"
+    compiler: ": #stack 8.0.2"
     addons:
       artifacts: {paths: [./releases]}
-      apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}
+      apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}
 
   # Nightly builds are allowed to fail
   - env: BUILD=stack ARGS="--resolver nightly"
     compiler: ": #stack nightly"
-    addons: {apt: {packages: [libgmp,libgmp-dev]}}
+    addons: {apt: {packages: [libgmp-dev]}}
 
   # Build on OS X in addition to Linux
   - env: BUILD=stack ARGS=""
     compiler: ": #stack default osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-5"
-    compiler: ": #stack 7.10.3 osx"
+  - env: BUILD=stack ARGS="--resolver lts-9.10"
+    compiler: ": #stack 8.0.2 osx"
     addons:
       artifacts: {paths: [./releases]}
     os: osx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM haskell:7.10
-MAINTAINER Lukas Martinelli <me@lukasmartinelli.ch>
+FROM debian:stretch-slim as builder
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "575159689BEFB442" \
- && echo 'deb http://download.fpcomplete.com/debian jessie main' >> /etc/apt/sources.list.d/fpco.list \
- && apt-get update \
+RUN apt-get update \
  && apt-get install --no-install-recommends -y \
-    git=1:2.1.4-2.1+deb8u2 \
-    hlint=1.8.61-1+b2 \
-    stack \
+    build-essential=12.3 \
+    libffi-dev=3.2.1-6 \
+    libgmp-dev=2:6.1.2+dfsg-1 \
+    zlib1g-dev=1:1.2.8.dfsg-5 \
+    curl=7.52.1-5+deb9u2 \
+    ca-certificates=20161130+nmu1 \
+    git=1:2.11.0-3+deb9u2 \
+    netbase=5.4 \
  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://get.haskellstack.org/ | sh
 
 WORKDIR /opt/hadolint/
 COPY . /opt/hadolint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim as builder
+FROM debian:stretch-slim AS builder
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y \
@@ -17,13 +17,15 @@ RUN curl -sSL https://get.haskellstack.org/ | sh
 WORKDIR /opt/hadolint/
 COPY . /opt/hadolint
 RUN cp /usr/lib/gcc/x86_64-linux-gnu/6/crtbeginS.o /usr/lib/gcc/x86_64-linux-gnu/6/crtbeginT.o
-RUN stack install --install-ghc --ghc-options '-optl-static -fPIC -optc-Os -optl-pthread'
+RUN stack install --install-ghc \
+  --ghc-options '-optl-static -fPIC -optc-Os -optl-pthread' \
+  --force-dirty
 
 # COMPRESS WITH UPX
 RUN curl -sSL https://github.com/lalyos/docker-upx/releases/download/v3.91/upx >/usr/local/bin/upx \
   && chmod 755 /usr/local/bin/upx \
   && upx --best --ultra-brute /root/.local/bin/hadolint
 
-FROM busybox:1.27.2-glibc
+FROM busybox:1.27.2-glibc AS distro
 COPY --from=builder /root/.local/bin/hadolint /bin/
 CMD ["/bin/hadolint", "-"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,9 @@ COPY . /opt/hadolint
 RUN cp /usr/lib/gcc/x86_64-linux-gnu/6/crtbeginS.o /usr/lib/gcc/x86_64-linux-gnu/6/crtbeginT.o
 RUN stack install --install-ghc --ghc-options '-optl-static -fPIC -optc-Os -optl-pthread'
 
+# COMPRESS WITH UPX
+RUN curl -sSL https://github.com/lalyos/docker-upx/releases/download/v3.91/upx >/usr/local/bin/upx \
+  && chmod 755 /usr/local/bin/upx \
+  && upx --best --ultra-brute /root/.local/bin/hadolint
 ENV PATH="/opt/hadolint/.stack-work/install/x86_64-linux/lts-4.1/7.10.3/bin:$PATH"
 CMD ["hadolint", "-"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN curl -sSL https://get.haskellstack.org/ | sh
 
 WORKDIR /opt/hadolint/
 COPY . /opt/hadolint
-RUN stack install # --ghc-options='-optl-static -optl-pthread' --force-dirty
+RUN cp /usr/lib/gcc/x86_64-linux-gnu/6/crtbeginS.o /usr/lib/gcc/x86_64-linux-gnu/6/crtbeginT.o
+RUN stack install --install-ghc --ghc-options '-optl-static -fPIC -optc-Os -optl-pthread'
 
 ENV PATH="/opt/hadolint/.stack-work/install/x86_64-linux/lts-4.1/7.10.3/bin:$PATH"
 CMD ["hadolint", "-"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,7 @@ RUN stack install --install-ghc --ghc-options '-optl-static -fPIC -optc-Os -optl
 RUN curl -sSL https://github.com/lalyos/docker-upx/releases/download/v3.91/upx >/usr/local/bin/upx \
   && chmod 755 /usr/local/bin/upx \
   && upx --best --ultra-brute /root/.local/bin/hadolint
-ENV PATH="/opt/hadolint/.stack-work/install/x86_64-linux/lts-4.1/7.10.3/bin:$PATH"
-CMD ["hadolint", "-"]
+
+FROM busybox:1.27.2-glibc
+COPY --from=builder /root/.local/bin/hadolint /bin/
+CMD ["/bin/hadolint", "-"]

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,6 +11,7 @@ import Data.List (sort)
 import Text.Parsec (ParseError)
 import Control.Applicative
 import Options.Applicative hiding (ParseError)
+import Data.Semigroup
 
 type IgnoreRule = String
 data LintOptions = LintOptions { showVersion :: Bool

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module Main where
 
 import Hadolint.Parser
@@ -12,6 +14,7 @@ import Text.Parsec (ParseError)
 import Control.Applicative
 import Options.Applicative hiding (ParseError)
 import Data.Semigroup
+import Development.GitRev (gitDescribe)
 
 type IgnoreRule = String
 data LintOptions = LintOptions { showVersion :: Bool
@@ -52,7 +55,11 @@ lintDockerfile ignoreRules dockerfile = do
     checkAst (ignoreFilter ignoreRules) ast
 
 lint :: LintOptions -> IO ()
-lint (LintOptions True _ _) = putStrLn "Haskell Dockerfile Linter v1.2.1" >> exitSuccess
+lint (LintOptions True _ _) =
+  let res = $(gitDescribe) in
+  let b = "Haskell Dockerfile Linter " in
+  let final_res = b ++ res in
+  putStrLn final_res >> exitSuccess
 lint (LintOptions _ _ []) = putStrLn "Please provide a Dockerfile" >> exitFailure
 lint (LintOptions _ ignored dfiles) = mapM_ (lintDockerfile ignored) dfiles
 

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -1,5 +1,5 @@
 name:                hadolint
-version:             1.2.1.0
+version:             1.2.2
 synopsis:            Dockerfile Linter JavaScript API
 homepage:            https://github.com/lukasmartinelli/hadolint
 license:             MIT
@@ -36,6 +36,7 @@ executable hadolint
                      , hadolint
                      , parsec >=3.1
                      , optparse-applicative <0.14.0.0
+                     , gitrev >= 1.3.1
   default-language:    Haskell2010
 
 test-suite hadolint-unit-tests

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -26,7 +26,7 @@ library
                      , parsec >=3.1
                      , bytestring >=0.10
                      , split >= 0.2
-                     , ShellCheck
+                     , ShellCheck >= 0.4.6
   default-language:    Haskell2010
 
 executable hadolint
@@ -35,7 +35,7 @@ executable hadolint
   build-depends:       base >=4.8 && < 5
                      , hadolint
                      , parsec >=3.1
-                     , optparse-applicative <0.13.0.0
+                     , optparse-applicative <0.14.0.0
   default-language:    Haskell2010
 
 test-suite hadolint-unit-tests
@@ -46,7 +46,7 @@ test-suite hadolint-unit-tests
                      , parsec >=3.1
                      , bytestring >=0.10
                      , split >= 0.2
-                     , ShellCheck
+                     , ShellCheck >= 0.4.6
                      , HUnit >= 1.2
                      , hspec
                      , hadolint

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -35,7 +35,7 @@ executable hadolint
   build-depends:       base >=4.8 && < 5
                      , hadolint
                      , parsec >=3.1
-                     , optparse-applicative <0.14.0.0
+                     , optparse-applicative <=0.14.0.0
                      , gitrev >= 1.3.1
   default-language:    Haskell2010
 

--- a/src/Hadolint/Bash.hs
+++ b/src/Hadolint/Bash.hs
@@ -6,7 +6,7 @@ import Data.Functor.Identity (runIdentity)
 
 shellcheck :: String -> [Comment]
 shellcheck bashScript = map comment $ crComments $ runIdentity $ checkScript si spec
-    where comment (PositionedComment _ c) = c
+    where comment (PositionedComment _ _ c) = c
           si = mockedSystemInterface [("","")]
           spec = CheckSpec filename script exclusions (Just Bash)
           script = "#!/bin/bash\n" ++ bashScript

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,14 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.9
+resolver: lts-9.10
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: [ShellCheck-0.4.4]
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
- Update GHC to `lts-9.10` and base image to Debian `stretch` as `jessie` (used in haskell image) is no longer supported
- Support a new version of `ShellCheck` (0.4.6+)
- Build hadolint as a static binary
  ```
  --ghc-options '-optl-static -fPIC -optc-Os -optl-pthread'
  ```
- Compress it with `upx`
  ```
                        Ultimate Packer for eXecutables
                          Copyright (C) 1996 - 2013
  UPX 3.91        Markus Oberhumer, Laszlo Molnar & John Reiser   Sep 30th 2013

        File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
  17335248 ->   2345924   13.53%  linux/ElfAMD   hadolint

  ```
- Use multistage docker build to be able to get minimal size image (4.39 MB) [zemanlx/hadolint](https://hub.docker.com/r/zemanlx/hadolint/)
- Add version number from `git describe` (a tag has to be to annotated)
  ```bash
  $ hadolint --version
  Haskell Dockerfile Linter v1.2.2-14-gc34be3a
  ```
- Add Docker image build to Travis + _self-lint_ as a check