### PR TITLE
Support for pip install arguments --user and --disable-pip-version-check

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -264,7 +264,9 @@ pipVersionPinned = instructionRule code severity message check
           versionFixed package = hasVersionSymbol package || isVersionedGit package
 
           packages :: [String] -> [String]
-          packages args = concat [drop 2 cmd | cmd <- bashCommands args, isPipInstall cmd]
+          packages args = concat [filter noOption cmd | cmd <- bashCommands args, isPipInstall cmd]
+              where noOption arg = arg `notElem` options
+                    options = [ "pip" , "pip2" , "pip3" , "install" , "--user" , "--disable-pip-version-check" ]
 
           isPipInstall :: [String] -> Bool
           isPipInstall cmd = ["pip", "install"] `isInfixOf` cmd || ["pip3", "install"] `isInfixOf` cmd || ["pip2", "install"] `isInfixOf` cmd

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -201,6 +201,10 @@ main = hspec $ do
     it "pip install upper bound" $ ruleCatchesNot pipVersionPinned "RUN pip install 'alabaster>=0.7'"
     it "pip install lower bound" $ ruleCatchesNot pipVersionPinned "RUN pip install 'alabaster<0.7'"
     it "pip install excluded version" $ ruleCatchesNot pipVersionPinned "RUN pip install 'alabaster!=0.7'"
+    it "pip install user directory" $ ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --user"
+    it "pip install no pip version check" $ ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --disable-pip-version-check"
+    it "pip install extra argument with '--'" $ ruleCatches pipVersionPinned "RUN pip install MySQL_python==1.2.2 --user --extra-arg"
+    it "pip install extra argument with '-'" $ ruleCatches pipVersionPinned "RUN pip install MySQL_python==1.2.2 --user -X"
 
   describe "use SHELL" $ do
     it "RUN ln" $ ruleCatches useShell "RUN ln -sfv /bin/bash /bin/sh"


### PR DESCRIPTION
Add support for `pip install` arguments `--user` and `--disable-pip-version-check` without breaking pip packages version pinning + some tests to `Spec.hs`.

Resolves @agounaris and @zemanlx requests from https://github.com/lukasmartinelli/hadolint/issues/67 