### PR TITLE
Build static binaries ...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,5 +109,5 @@ install:
 
 script:
 - stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
-- stack --no-terminal $ARGS install --ghc-options='-O0'
+- stack --no-terminal $ARGS install --ghc-options='-fPIC'
 - cp "$(which hadolint)" ./releases/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,7 @@ RUN curl -sSL https://get.haskellstack.org/ | sh
 
 WORKDIR /opt/hadolint/
 COPY . /opt/hadolint
-RUN stack install --install-ghc \
-  --ghc-options '-optl-static -fPIC -optc-Os -optl-pthread' \
-  --force-dirty
+RUN stack install --install-ghc --ghc-options="-fPIC"
 
 # COMPRESS WITH UPX
 RUN curl -sSL https://github.com/lalyos/docker-upx/releases/download/v3.91/upx >/usr/local/bin/upx \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN curl -sSL https://get.haskellstack.org/ | sh
 
 WORKDIR /opt/hadolint/
 COPY . /opt/hadolint
-RUN cp /usr/lib/gcc/x86_64-linux-gnu/6/crtbeginS.o /usr/lib/gcc/x86_64-linux-gnu/6/crtbeginT.o
 RUN stack install --install-ghc \
   --ghc-options '-optl-static -fPIC -optc-Os -optl-pthread' \
   --force-dirty

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -38,6 +38,9 @@ executable hadolint
                      , optparse-applicative <=0.14.0.0
                      , gitrev >= 1.3.1
   default-language:    Haskell2010
+  -- OS X does not support static build https://developer.apple.com/library/content/qa/qa1118
+  if !os(OSX)
+    ld-options:        -static -pthread
 
 test-suite hadolint-unit-tests
   hs-source-dirs:      test


### PR DESCRIPTION
... if it is an option. As I have learnt that [OS X does not support static binaries](https://developer.apple.com/library/content/qa/qa1118) for `c`. Linux and Windows builds are now build with `--static` option. 

Linux builds are static
```bash
$ ldd .stack-work/dist/x86_64-linux/*/build/hadolint/hadolint                                                                    
.stack-work/dist/x86_64-linux/Cabal-1.24.2.0/build/hadolint/hadolint:
        not a dynamic executable
.stack-work/dist/x86_64-linux/Cabal-2.0.0.2/build/hadolint/hadolint:
        not a dynamic executable
```

I do not have experience in Windows world but I have tried it to run on a fresh Windows Server 2016 installation and it was running :tada:.

@lukasmartinelli is this what you have been doing for https://github.com/lukasmartinelli/hadolint/issues/49 ?