### PR TITLE
Travis cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ matrix:
       # Lint its own Dockerfile
       - docker run --rm -i hadolint:$(git describe --tags --dirty) < Dockerfile
       # Check that version in hadolint in the same as its `git describe`
-      # This can be enabled when there is an annotated tag
-      # - grep $(git describe --dirty) <<< $(docker run --rm -i hadolint:$(git describe --tags --dirty) hadolint --version)
+      - grep $(git describe --dirty) <<<
+        $(docker run --rm -i hadolint:$(git describe --tags --dirty) hadolint --version)
 
   allow_failures:
   - env: ARGS="--resolver nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
   directories:
   - $HOME/.ghc
   - $HOME/.stack
+  timeout: 300
 
 # We set the compiler values here to tell Travis to use a different
 # cache file per set of arguments.

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,33 +25,33 @@ matrix:
   include:
   # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
-  - env: BUILD=stack ARGS=""
+  - env: ARGS=""
     compiler: ": #stack default"
     addons: {apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-9.10"
+  - env: ARGS="--resolver lts-9.10"
     compiler: ": #stack 8.0.2"
     addons:
       artifacts: {paths: [./releases]}
       apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}
 
   # Nightly builds are allowed to fail
-  - env: BUILD=stack ARGS="--resolver nightly"
+  - env: ARGS="--resolver nightly"
     compiler: ": #stack nightly"
     addons: {apt: {packages: [libgmp-dev]}}
 
   # Build on OS X in addition to Linux
-  - env: BUILD=stack ARGS=""
+  - env: ARGS=""
     compiler: ": #stack default osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-9.10"
+  - env: ARGS="--resolver lts-9.10"
     compiler: ": #stack 8.0.2 osx"
     addons:
       artifacts: {paths: [./releases]}
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver nightly"
+  - env: ARGS="--resolver nightly"
     compiler: ": #stack nightly osx"
     os: osx
 
@@ -77,7 +77,7 @@ matrix:
       # - grep $(git describe --dirty) <<< $(docker run --rm -i hadolint:$(git describe --tags --dirty) hadolint --version)
 
   allow_failures:
-  - env: BUILD=stack ARGS="--resolver nightly"
+  - env: ARGS="--resolver nightly"
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,9 +84,11 @@ before_install:
 - |
   if [ `uname` = "Darwin" ]
   then
-    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 \
+      | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
   else
-    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 \
+      | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
   include:
   # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
-    addons: {apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}}
   - env: ARGS="--resolver lts"
     compiler: ": #stack lastest LTS Linux"
 
@@ -33,11 +32,9 @@ matrix:
     compiler: ": #stack 8.0.2"
     addons:
       artifacts: {paths: [./releases]}
-      apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}
 
   # Nightly builds are allowed to fail
   - env: ARGS="--resolver nightly"
-    addons: {apt: {packages: [libgmp-dev]}}
     compiler: ": #stack nightly Linux"
 
   # Build on OS X in addition to Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ compiler: gcc
 # Caching so the next build will be fast too.
 cache:
   directories:
-  - $HOME/.ghc
   - $HOME/.stack
   timeout: 300
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
     before_install: true
     install:
       # Build image
-      - docker build -t hadolint:$(git describe --tags --dirty) .
+      - travis_wait 30 docker build -t hadolint:$(git describe --tags --dirty) .
     script:
       # List images
       - docker image ls
@@ -82,7 +82,7 @@ before_install:
 
 install:
 - mkdir -p ./releases/
-- stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+- travis_retry stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
 
 script:
 - stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ matrix:
   include:
   # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
-  - env: ARGS=""
-    compiler: ": #stack default"
     addons: {apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}}
+  - env: ARGS="--resolver lts"
+    compiler: ": #stack lastest LTS Linux"
 
   - env: ARGS="--resolver lts-9.10"
     compiler: ": #stack 8.0.2"
@@ -37,22 +37,22 @@ matrix:
 
   # Nightly builds are allowed to fail
   - env: ARGS="--resolver nightly"
-    compiler: ": #stack nightly"
     addons: {apt: {packages: [libgmp-dev]}}
+    compiler: ": #stack nightly Linux"
 
   # Build on OS X in addition to Linux
-  - env: ARGS=""
-    compiler: ": #stack default osx"
+  - env: ARGS="--resolver lts"
+    compiler: ": #stack latest LTS OSX"
     os: osx
 
   - env: ARGS="--resolver lts-9.10"
-    compiler: ": #stack 8.0.2 osx"
+    compiler: ": #stack 8.0.2 OSX"
     addons:
       artifacts: {paths: [./releases]}
     os: osx
 
   - env: ARGS="--resolver nightly"
-    compiler: ": #stack nightly osx"
+    compiler: ": #stack nightly OSX"
     os: osx
 
   - env: Build_Docker_Image

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,8 @@ language: c
 cache:
   directories:
   - $HOME/.ghc
-  - $HOME/.cabal
   - $HOME/.stack
 
-# The different configurations we want to test. We have BUILD=cabal which uses
-# cabal-install, and BUILD=stack which uses Stack. More documentation on each
-# of those below.
-#
 # We set the compiler values here to tell Travis to use a different
 # cache file per set of arguments.
 #
@@ -77,8 +72,6 @@ matrix:
   - env: ARGS="--resolver nightly"
 
 before_install:
-# Using compiler above sets CC to an invalid value, so unset it
-- unset CC
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,6 @@ before_install:
 # Using compiler above sets CC to an invalid value, so unset it
 - unset CC
 # Download and unpack the stack executable
-- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
 - mkdir -p ~/.local/bin
 - |
   if [ `uname` = "Darwin" ]
@@ -92,8 +91,6 @@ before_install:
 
 install:
 - mkdir -p ./releases/
-- echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
-- if [ -f configure.ac ]; then autoreconf -i; fi
 - stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,11 +90,6 @@ before_install:
     travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   fi
 
-  # Use the more reliable S3 mirror of Hackage
-  mkdir -p $HOME/.cabal
-  echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
-  echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
-
 install:
 - mkdir -p ./releases/
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ matrix:
       # Check that version in hadolint in the same as its `git describe`
       - grep $(git describe --dirty) <<<
         $(docker run --rm -i hadolint:$(git describe --tags --dirty) hadolint --version)
+    after_success: true
 
   allow_failures:
   - env: ARGS="--resolver nightly"
@@ -90,5 +91,7 @@ install:
 
 script:
 - stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
+
+after_success:
 - stack --no-terminal $ARGS install --ghc-options='-fPIC'
 - cp "$(which hadolint)" ./releases/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 
 # Choose a lightweight base image; we provide our own build tools.
 language: c
+compiler: gcc
 
 # Caching so the next build will be fast too.
 cache:
@@ -21,30 +22,24 @@ matrix:
   # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
   - env: ARGS="--resolver lts"
-    compiler: ": #stack lastest LTS Linux"
 
   - env: ARGS="--resolver lts-9.10"
-    compiler: ": #stack 8.0.2"
     addons:
       artifacts: {paths: [./releases]}
 
   # Nightly builds are allowed to fail
   - env: ARGS="--resolver nightly"
-    compiler: ": #stack nightly Linux"
 
   # Build on OS X in addition to Linux
   - env: ARGS="--resolver lts"
-    compiler: ": #stack latest LTS OSX"
     os: osx
 
   - env: ARGS="--resolver lts-9.10"
-    compiler: ": #stack 8.0.2 OSX"
     addons:
       artifacts: {paths: [./releases]}
     os: osx
 
   - env: ARGS="--resolver nightly"
-    compiler: ": #stack nightly OSX"
     os: osx
 
   - env: Build_Docker_Image

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,9 +98,6 @@ before_install:
   echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
   echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
 
-# Get the list of packages from the stack.yaml file
-- PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
-
 install:
 - mkdir -p ./releases/
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"


### PR DESCRIPTION
Big clean-up in `.travis.yml`. 
- Removed a lot of not used stuff.
- Get caching working again for OS X. 
- `stack default` was the same as `--resolver lts-9.10` therefore, I have replaced it with the latest LTS `--resolver lts`