### PR TITLE
Fetch tags and last 100 commits to get a version for shallow clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN curl -sSL https://get.haskellstack.org/ | sh
 
 WORKDIR /opt/hadolint/
 COPY . /opt/hadolint
-RUN stack install --install-ghc --ghc-options="-fPIC"
+RUN scripts/fetch_version.sh \
+  && stack install --install-ghc --ghc-options="-fPIC"
 
 # COMPRESS WITH UPX
 RUN curl -sSL https://github.com/upx/upx/releases/download/v3.94/upx-3.94-amd64_linux.tar.xz \

--- a/scripts/fetch_version.sh
+++ b/scripts/fetch_version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# In case of shallow clone fetch repo tags and 100 commits to get full
+# `git description` message for `hadolint --version`
+
+set -evuo pipefail
+
+# Get remote URL which can have two formats
+# git@github.com:lukasmartinelli/hadolint.git
+# https://github.com/lukasmartinelli/hadolint 
+
+url=$(git remote get-url origin)
+# if URL is for SSH, change it to HTTPS format
+if [[ $url =~ "git@" ]]; then 
+  url=https://github.com/$(cut -f 2 -d ":" <<< "$url")
+fi
+
+git fetch --tags "$url"
+git fetch --depth=100 "$url"


### PR DESCRIPTION
The shallow clone is used in Docker Hub automated build, therefore we missing version number there and not in Travis where clone has `depth=50`.

Resolve #105. 