### PR TITLE
Add checks for `latest` as tag for named image

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -191,8 +191,11 @@ noLatestTag = instructionRule code severity message check
     where code = "DL3007"
           severity = WarningC
           message = "Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag."
-          check (From (TaggedImage _ "latest")) = False
-          check (From (TaggedImage _ _)) = True
+          check (From (TaggedImage _ tag)) =
+            not
+              (isPrefixOf "latest AS" tag ||
+               isPrefixOf "latest as" tag ||
+               tag == "latest")
           check _ = True
 
 aptGetVersionPinned = instructionRule code severity message check

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -147,8 +147,12 @@ main = hspec $ do
 
   describe "FROM rules" $ do
     it "no untagged" $ ruleCatches noUntagged "FROM debian"
+    it "no untagged with name" $ ruleCatches noUntagged "FROM debian AS builder"
     it "explicit latest" $ ruleCatches noLatestTag "FROM debian:latest"
+    it "explicit latest with name" $ ruleCatches noLatestTag "FROM debian:latest AS builder"
     it "explicit tagged" $ ruleCatchesNot noLatestTag "FROM debian:jessie"
+    it "explicit SHA" $ ruleCatchesNot noLatestTag "FROM debian@sha256:7959ed6f7e35f8b1aaa06d1d8259d4ee25aa85a086d5c125480c333183f9deeb"
+    it "explicit tagged with name" $ ruleCatchesNot noLatestTag "FROM debian:jessie AS builder"
 
   describe "no root or sudo rules" $ do
     it "sudo" $ ruleCatches noSudo "RUN sudo apt-get update"


### PR DESCRIPTION
Multistage build added optional names for images, which can be used later within Dockerfile.

```Dockerfile
FROM <image> [AS <name>]
```

or

```Dockerfile
FROM <image>[:<tag>] [AS <name>]
```

or

```Dockerfile
FROM <image>[@<digest>] [AS <name>]
```

This PR fixes #108 by checking not only `latest` but also `latest as` or `latest AS`. I have also added tests to `Spec.hs`

https://docs.docker.com/engine/reference/builder/#from