### PR TITLE
Check for root defined as UID 0 or root with group

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -154,8 +154,12 @@ noRootUser = instructionRule code severity message check
     where code = "DL3002"
           severity = ErrorC
           message = "Do not switch to root USER"
-          check (User "root") = False
-          check (User _) = True
+          check (User user) =
+            not
+              (isPrefixOf "root:" user ||
+               isPrefixOf "0:" user ||
+               user == "root" ||
+               user == "0")
           check _ = True
 
 noCd = instructionRule code severity message check

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -153,6 +153,10 @@ main = hspec $ do
   describe "no root or sudo rules" $ do
     it "sudo" $ ruleCatches noSudo "RUN sudo apt-get update"
     it "no root" $ ruleCatches noRootUser "USER root"
+    it "no root" $ ruleCatchesNot noRootUser "USER foo"
+    it "no root UID" $ ruleCatches noRootUser "USER 0"
+    it "no root:root" $ ruleCatches noRootUser "USER root:root"
+    it "no root UID:GID" $ ruleCatches noRootUser "USER 0:0"
     it "install sudo" $ ruleCatchesNot noSudo "RUN apt-get install sudo"
     it "sudo chained programs" $ ruleCatches noSudo "RUN apt-get update && sudo apt-get install"
 


### PR DESCRIPTION
This PR fixes #109 by checking that user is not only `root` by also `root:*` or `0` (root's user id) or `0:*` as `USER` can be defined as 

```Dockerfile
USER <user>[:<group>]
```

or


```Dockerfile
USER <UID>[:<GID>]
```

https://docs.docker.com/engine/reference/builder/#user