### PR TITLE
Issue84/last cmd take effect

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -126,7 +126,7 @@ multipleCmds =dockerfileRule code severity message check
 multipleEntrypoints =dockerfileRule code severity message check
     where code = "DL4004"
           severity = ErrorC
-          message = "Multiple `ENTRYPOINT` instructions found. Only the first instruction will take effect."
+          message = "Multiple `ENTRYPOINT` instructions found. If you list more than one `ENTRYPOINT` then only the last `ENTRYPOINT` will take effect."
           check dockerfile = 1 >= length (filter (True==) $ map isEntrypoint dockerfile)
           isEntrypoint (Entrypoint _) = True
           isEntrypoint _       = False

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -118,7 +118,7 @@ usingProgram prog args = or [head cmds == prog | cmds <- bashCommands args]
 multipleCmds =dockerfileRule code severity message check
     where code = "DL4003"
           severity = WarningC
-          message = "Multiple `CMD` instructions found. Only the first instruction will take effect."
+          message = "Multiple `CMD` instructions found. If you list more than one `CMD` then only the last `CMD` will take effect."
           check dockerfile = 1 >= length (filter (True==) $ map isCmd dockerfile)
           isCmd (Cmd _) = True
           isCmd _       = False


### PR DESCRIPTION
Fixes #84 where we reported that only first `CMD` take effect, but it is vice-versa. The same issue is with multiple `ENTRYPOINT`.

I have also updated the wiki.