### PR TITLE
npm version pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Please [create an issue](https://github.com/lukasmartinelli/hadolint/issues/new)
 | [DL3013](https://github.com/lukasmartinelli/hadolint/wiki/DL3013) | Pin versions in pip.
 | [DL3014](https://github.com/lukasmartinelli/hadolint/wiki/DL3014) | Use the `-y` switch.
 | [DL3015](https://github.com/lukasmartinelli/hadolint/wiki/DL3015) | Avoid additional packages by specifying --no-install-recommends.
+| [DL3016](https://github.com/lukasmartinelli/hadolint/wiki/DL3016) | Pin versions in `npm`.
 | [DL3020](https://github.com/lukasmartinelli/hadolint/wiki/DL3020) | Use `COPY` instead of `ADD` for files and folders.
 | [DL4000](https://github.com/lukasmartinelli/hadolint/wiki/DL4000) | Specify a maintainer of the Dockerfile.
 | [DL4001](https://github.com/lukasmartinelli/hadolint/wiki/DL4001) | Either use Wget or Curl but not both.
@@ -168,4 +169,3 @@ Dockerfile syntax is fully described in the [Dockerfile reference](http://docs.d
 - https://github.com/RedCoolBeans/dockerlint/
 - https://github.com/projectatomic/dockerfile_lint/
 - http://dockerfile-linter.com/
-

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -206,6 +206,27 @@ main = hspec $ do
     it "pip install extra argument with '--'" $ ruleCatches pipVersionPinned "RUN pip install MySQL_python==1.2.2 --user --extra-arg"
     it "pip install extra argument with '-'" $ ruleCatches pipVersionPinned "RUN pip install MySQL_python==1.2.2 --user -X"
 
+  describe "npm pinning" $ do
+    it "version pinned in package.json" $ ruleCatchesNot npmVersionPinned "RUN npm install"
+    it "version pinned" $ ruleCatchesNot npmVersionPinned "RUN npm install express@4.1.1"
+    it "version pinned with scope" $ ruleCatchesNot npmVersionPinned "RUN npm install @myorg/privatepackage@\">=0.1.0\""
+    it "version pinned multiple packages" $ ruleCatchesNot npmVersionPinned "RUN npm install express@\"4.1.1\" sax@0.1.1"
+    it "version pinned with --global" $ ruleCatchesNot npmVersionPinned "RUN npm install --global express@\"4.1.1\""
+    it "commit pinned for git+ssh" $ ruleCatchesNot npmVersionPinned "RUN npm install git+ssh://git@github.com:npm/npm.git#v1.0.27"
+    it "commit pinned for git+http" $ ruleCatchesNot npmVersionPinned "RUN npm install git+http://isaacs@github.com/npm/npm#semver:^5.0"
+    it "commit pinned for git+https" $ ruleCatchesNot npmVersionPinned "RUN npm install git+https://isaacs@github.com/npm/npm.git#v1.0.27"
+    it "commit pinned for git" $ ruleCatchesNot npmVersionPinned "RUN npm install git://github.com/npm/npm.git#v1.0.27"
+    --version range is not supported
+    --it "version pinned with scope" $ ruleCatchesNot npmVersionPinned "RUN npm install @myorg/privatepackage@\">=0.1.0 <0.2.0\""
+    it "version not pinned" $ ruleCatches npmVersionPinned "RUN npm install express"
+    it "version not pinned with scope" $ ruleCatches npmVersionPinned "RUN npm install @myorg/privatepackage"
+    it "version not pinned multiple packages" $ ruleCatches npmVersionPinned "RUN npm install express sax@0.1.1"
+    it "version not pinned with --global" $ ruleCatches npmVersionPinned "RUN npm install --global express"
+    it "commit not pinned for git+ssh" $ ruleCatches npmVersionPinned "RUN npm install git+ssh://git@github.com:npm/npm.git"
+    it "commit not pinned for git+http" $ ruleCatches npmVersionPinned "RUN npm install git+http://isaacs@github.com/npm/npm"
+    it "commit not pinned for git+https" $ ruleCatches npmVersionPinned "RUN npm install git+https://isaacs@github.com/npm/npm.git"
+    it "commit not pinned for git" $ ruleCatches npmVersionPinned "RUN npm install git://github.com/npm/npm.git"
+
   describe "use SHELL" $ do
     it "RUN ln" $ ruleCatches useShell "RUN ln -sfv /bin/bash /bin/sh"
     it "RUN ln with unrelated symlinks" $ ruleCatchesNot useShell "RUN ln -sf /bin/true /sbin/initctl"


### PR DESCRIPTION
Pinning supports various formats

```bash
npm install (with no args, in package dir)
npm install [<@scope>/]<name>
npm install [<@scope>/]<name>@<tag>
npm install [<@scope>/]<name>@<version>
npm install git[+http|+https]://<git-host>/<git-user>/<repo-name>[#<commit>|#semver:<semver>]
npm install git+ssh://<git-host>:<git-user>/<repo-name>[#<commit>|#semver:<semver>]
```
and one flag `--global`.

I have also added wiki page for [DL3016](https://github.com/lukasmartinelli/hadolint/wiki/DL3016)

Fixes #3.