### PR TITLE
Accept `--no-cache-dir` option in `pip install`

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -266,7 +266,15 @@ pipVersionPinned = instructionRule code severity message check
           packages :: [String] -> [String]
           packages args = concat [filter noOption cmd | cmd <- bashCommands args, isPipInstall cmd]
               where noOption arg = arg `notElem` options
-                    options = [ "pip" , "pip2" , "pip3" , "install" , "--user" , "--disable-pip-version-check" ]
+                    options =
+                      [ "pip"
+                      , "pip2"
+                      , "pip3"
+                      , "install"
+                      , "--user"
+                      , "--disable-pip-version-check"
+                      , "--no-cache-dir"
+                      ]
 
           isPipInstall :: [String] -> Bool
           isPipInstall cmd = ["pip", "install"] `isInfixOf` cmd || ["pip3", "install"] `isInfixOf` cmd || ["pip2", "install"] `isInfixOf` cmd

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -203,6 +203,7 @@ main = hspec $ do
     it "pip install excluded version" $ ruleCatchesNot pipVersionPinned "RUN pip install 'alabaster!=0.7'"
     it "pip install user directory" $ ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --user"
     it "pip install no pip version check" $ ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --disable-pip-version-check"
+    it "pip install no cache dir" $ ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --no-cache-dir" 
     it "pip install extra argument with '--'" $ ruleCatches pipVersionPinned "RUN pip install MySQL_python==1.2.2 --user --extra-arg"
     it "pip install extra argument with '-'" $ ruleCatches pipVersionPinned "RUN pip install MySQL_python==1.2.2 --user -X"
 


### PR DESCRIPTION
`pip install` version pinning should not fail if user does not want to use local cache in Dockerfile, therefore this PR will accept [`--no-cache-dir`](https://pip.pypa.io/en/stable/reference/pip_install/#caching) as an option.

Fixes #115.