### PR TITLE
Add support for upx and new support for GitHub releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,92 +1,116 @@
-# Use new container infrastructure to enable caching
+# Build starts faster without `sudo`
 sudo: false
 
-# Choose a lightweight base image; we provide our own build tools.
 language: c
 compiler: gcc
 
-# Caching so the next build will be fast too.
 cache:
   directories:
   - $HOME/.stack
   timeout: 300
 
-# We set the compiler values here to tell Travis to use a different
-# cache file per set of arguments.
-#
-# If you need to have different apt packages for each combination in the
-# matrix, you can use a line such as:
-#     addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
+# Increase depth (from default 50) to preserve version from `git describe`
+git:
+  depth: 100
+
 matrix:
   include:
-  # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
-  # variable, such as using --stack-yaml to point to a different file.
-  - env: ARGS="--resolver lts"
+    # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
+    # variable, such as using --stack-yaml to point to a different file.
+    - env: ARGS="--resolver lts"
 
-  - env: ARGS="--resolver lts-9.10"
-    addons:
-      artifacts: {paths: [./releases]}
+    - env: ARGS="--resolver lts-9.10"
+      addons:
+        artifacts: {paths: [./releases]}
+      before_deploy:
+        # Show dynamic libraries `hadolint` depends on
+        - ldd $(which hadolint) || true
+        - curl -sSL https://github.com/upx/upx/releases/download/v3.94/upx-3.94-amd64_linux.tar.xz
+          | tar -x --xz --strip-components=1 -C ~/.local/bin upx-3.94-amd64_linux/upx
+        # Compress binary
+        - upx -q --best --ultra-brute "./releases/${BINARY_NAME}"
+      deploy: &release_deploy
+        provider: releases
+        api_key:
+          secure: mBAlUlWKILccrQK9S118syLIh17r6WNrQUqAZTMiKUS3cgGnPp514bSrS+0igfXgy0p87OT7DHy1MYs0AGcJbEwsE3NU3WMiKCyWR+WEXmjliHvdhIjwunEvHb1E3a6BPvC+rzLP4cMB6xfTJqYGHfdd8cp7MfFyjRA2njATRaeGL/vu17Z15lFxnq4iPECLDiRnyWS9vPj7szrzdYhbV603Awm3Oq+zmZM9etBfuZbwB6IJf8lTlw1c3EouIq2FklISWpoXivhz71nmshcLoUpXVuXL5mvBOePyVLLc9CHfrhwrOtyQ3adqWWLRkoKOJJ8M5x5Y5XODqDLlAEgkVz4DLFrnOnU9B49plwUcnQj617G2IMLGd2U/wbz6l28An2x5PgfJ1K8au4i52XDA+n28keH/2DzVDsmt9lafC6Ouvtzk8BzKYOdNbBkGXZFyLxNBHKoPUawi13WQe/Bo3+1EoXSst0AkDZkf/+Zi8tXq/ZLGkymt3AH2klMIVnki5krVzEOZAuo0KS3mugFwNmj/1ZGJ5M5+Ia3r557NYo+MkJQv55uFGtHDniMO0Xadp9MiOH1jiZUv6grTDJZ+wYHxZDFQHGa821Udpf6Y4U567gQTVrmk1vGz1/K7xrOeyJzTG1zCV5CcYEEQz02OBdnoSXSK3Gw6yNv/MMca7kk=
+        file: "./releases/${BINARY_NAME}"
+        skip_cleanup: true
+        draft: true
+        tag_name: "${TRAVIS_TAG}"
+        on:
+          tags: true
 
-  # Nightly builds are allowed to fail
-  - env: ARGS="--resolver nightly"
+    # Nightly builds are allowed to fail
+    - env: ARGS="--resolver nightly"
 
-  # Build on OS X in addition to Linux
-  - env: ARGS="--resolver lts"
-    os: osx
+    # Build on OS X in addition to Linux
+    - env: ARGS="--resolver lts"
+      os: osx
 
-  - env: ARGS="--resolver lts-9.10"
-    addons:
-      artifacts: {paths: [./releases]}
-    os: osx
+    - env: ARGS="--resolver lts-9.10"
+      addons:
+        artifacts: {paths: [./releases]}
+      before_deploy:
+        # Show dynamic libraries `hadolint` depends on
+        - otool -L $(which hadolint) || true
+        - brew update > /dev/null
+        - brew install upx
+        # Compress binary
+        - upx -q --best --ultra-brute "./releases/${BINARY_NAME}"
+      deploy:
+        <<: *release_deploy
+      os: osx
 
-  - env: ARGS="--resolver nightly"
-    os: osx
+    - env: ARGS="--resolver nightly"
+      os: osx
 
-  - env: Build_Docker_Image
-    sudo: required
-    services:
-      - docker
-    addons:
-      apt:
-        packages:
-          - docker-ce
-    before_install: true
-    install:
-      # Build image
-      - travis_wait 30 docker build -t hadolint:$(git describe --tags --dirty) .
-    script:
-      # List images
-      - docker image ls
-      # Lint its own Dockerfile
-      - docker run --rm -i hadolint:$(git describe --tags --dirty) < Dockerfile
-      # Check that version in hadolint in the same as its `git describe`
-      - grep $(git describe --dirty) <<<
-        $(docker run --rm -i hadolint:$(git describe --tags --dirty) hadolint --version)
-    after_success: true
+    - env: Build_Docker_Image
+      sudo: required
+      services:
+        - docker
+      addons:
+        apt:
+          packages:
+            - docker-ce
+      before_install: true
+      install:
+        # Build image
+        - travis_wait 30 docker build -t hadolint:$(git describe --tags --dirty) .
+      script:
+        # List images
+        - docker image ls
+        # Lint its own Dockerfile
+        - docker run --rm -i hadolint:$(git describe --tags --dirty) < Dockerfile
+        # Check that version in hadolint in the same as its `git describe`
+        - grep $(git describe --dirty) <<<
+          $(docker run --rm -i hadolint:$(git describe --tags --dirty) hadolint --version)
+      after_success: true
 
   allow_failures:
-  - env: ARGS="--resolver nightly"
+    - env: ARGS="--resolver nightly"
 
 before_install:
-# Download and unpack the stack executable
-- mkdir -p ~/.local/bin
-- |
-  if [ `uname` = "Darwin" ]
-  then
-    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 \
-      | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
-  else
-    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 \
-      | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-  fi
+  - export BINARY_NAME="hadolint-$(uname -s)-$(uname -m)"
+  # Download and unpack the stack executable
+  - mkdir -p ~/.local/bin
+  - |
+    if [[ "${TRAVIS_OS_NAME}" = "osx" ]]
+    then
+      travis_retry curl -sSL https://www.stackage.org/stack/${TRAVIS_OS_NAME}-x86_64 \
+        | tar xz --strip-components=1 -C ~/.local/bin --include   '*/stack'
+    else
+      travis_retry curl -sSL https://www.stackage.org/stack/${TRAVIS_OS_NAME}-x86_64 \
+        | tar xz --strip-components=1 -C ~/.local/bin --wildcards '*/stack'
+    fi
 
 install:
-- mkdir -p ./releases/
-- travis_retry stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+  - travis_retry stack --no-terminal --install-ghc $ARGS test --only-dependencies
+  - stack --no-terminal $ARGS install --ghc-options='-fPIC'
 
 script:
-- stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
+  - stack --no-terminal $ARGS test
+  - hadolint Dockerfile
 
 after_success:
-- stack --no-terminal $ARGS install --ghc-options='-fPIC'
-- cp "$(which hadolint)" ./releases/
+  - mkdir -p ./releases/
+  - cp "$(which hadolint)" "./releases/${BINARY_NAME}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,38 @@
 build: off
 
+cache:
+  # Cache GHC
+  - 'C:\Users\appveyor\AppData\Local\Programs\stack'
+  # Cache cabal packages
+  - 'C:\Users\appveyor\AppData\Roaming\stack'
+
 before_build:
-- curl -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
-- 7z x stack.zip stack.exe
+  - choco install haskell-stack
 
 build_script:
-# Suppress output from stack setup, as there is a lot and it's not necessary.
-- stack setup --no-terminal > nul
-- stack build --only-snapshot --no-terminal
-- stack --local-bin-path . install hadolint
+  # Suppress output from stack, as there is a lot and it's not necessary.
+  - stack --no-terminal --install-ghc test --only-dependencies > nul
+  - stack --no-terminal --local-bin-path . install
+
+test_script:
+  - stack test
+  - hadolint.exe Dockerfile
+
+after_test:
+  - rename hadolint.exe hadolint-Windows-x86_64.exe
+
+before_deploy:
+  - choco install upx
+  - upx --best --ultra-brute hadolint-Windows-x86_64.exe
+
+deploy:
+  provider: GitHub
+  auth_token:
+    secure: VRfoSAuhleshm1Fpe3Kq0ujYytPKodV+fu1kJHiBrZ8d1QW3kOBS89XZ+XVrxdhs
+  artifact: hadolint-Windows-x86_64.exe
+  on:
+    appveyor_repo_tag: true
 
 artifacts:
-- path: hadolint.exe
+  - path: hadolint-Windows-x86_64.exe
+    name: Releases

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,23 @@
+# Release procedure
+
+Only `master` branch is used for releases.
+
+1. Write a **draft** of release where _tag version_ and _release title_ are
+  the same as a version of `hadolint`, eg `v1.2.3`.
+  ![draft](https://user-images.githubusercontent.com/18702153/32983073-f7477820-cc86-11e7-92c6-fabfc1223a25.png)
+
+2. Create an annotated tag with tag name as a message and push it back to
+ `lukasmartinelli/hadolint` remote. Release notes should be in the draft not
+ in a tag message.
+  ```bash
+  export TAG=v1.2.3
+  git tag -a "$TAG" -m "$TAG" && git push origin "$TAG"
+  ```
+
+3. Tag creation will trigger build in _Travis_ and _AppVeyor_ which will upload
+  binaries to GitHub release draft with the same name as is the name of the tag
+  (created in step 1).
+  ![draft_binaries](https://user-images.githubusercontent.com/18702153/32983247-7692d528-cc89-11e7-9340-2af1434a6bdf.png)
+
+4. Edit release notes, mention all new features and important fixes and
+  publish it.


### PR DESCRIPTION
### Changes 

1. Use GitHub Releases deployment feature to upload binaries for each release automatically. 
2. For making binaries as small as possible (for frequent download in CI environment) I have added `upx` compression for tagged/release builds for all 3 OS we support.

There are a few more minor changes included in this PR: 
- Name binaries hadolint-OS-ARCH.
- Use choco for stack install in AppVeyor.
- Use caching in AppVeyor.
- Sync Travis and AppVeyor stack commands as much as possible.
- Lint Travis and AppVeyor YAML files.

I have also added document how to make a release smooth with GitHub.

### Result

I have tested it in my fork
- Release builds in [Travis](https://travis-ci.org/zemanlx/hadolint/builds/304071070) and [AppVeyor](https://ci.appveyor.com/project/zemanlx/hadolint/build/1.0.99)
- Release artifacts in my fork release [t1.0.0](https://github.com/zemanlx/hadolint/releases/tag/t1.0.0)

### Possible risk

I am not sure that my secret will work for upstream releases, but I hope it will as far it is based on GitHub token.
